### PR TITLE
enable durability client for windows

### DIFF
--- a/src/durability/CMakeLists.txt
+++ b/src/durability/CMakeLists.txt
@@ -8,9 +8,11 @@
 #
 # SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
+include(GenerateExportHeader)
 idlc_generate(TARGET dcidl FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/durablesupport.idl")
 add_library(durability SHARED "${CMAKE_CURRENT_SOURCE_DIR}/src/dds_durability.c")
 set_property(TARGET durability PROPERTY C_VISIBILITY_PRESET hidden)
+generate_export_header(durability BASE_NAME DDS_DURABILITY EXPORT_FILE_NAME "${CMAKE_CURRENT_BINARY_DIR}/include/durability_export.h")
 target_include_directories(durability PRIVATE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
@@ -20,8 +22,9 @@ target_include_directories(durability PRIVATE
   "$<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src/core/cdr/include>"
   "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/ddsrt/include>"
   "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/core/include>"
+  "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src/durability/include>"
 )
-target_link_libraries(durability PRIVATE dcidl)
+target_link_libraries(durability PRIVATE dcidl ddsc)
 
 install(
   TARGETS durability

--- a/src/durability/include/dds/durability/dds_durability_private.h
+++ b/src/durability/include/dds/durability/dds_durability_private.h
@@ -11,14 +11,14 @@
 #ifndef DDS_DURABILITY_PRIVATE_H
 #define DDS_DURABILITY_PRIVATE_H
 
-#include "dds/export.h"
+#include "durability_export.h"
 #include "dds/durability/dds_durability_public.h"
 
 #if defined (__cplusplus)
 extern "C" {
 #endif
 
-DDS_EXPORT void dds_durability_creator(dds_durability_t* ds);
+DDS_DURABILITY_EXPORT void dds_durability_creator(dds_durability_t* ds);
 
 #if defined (__cplusplus)
 }


### PR DESCRIPTION
This PR enables Durability Client to be built for Windows with Visual Studio.

The cmake commands for building with Visual Studio:
```
cmake -G "Visual Studio 17 2022" -A x64 <your_other_flags> -S . -B ./bld
cmake --build ./bld
```

Before merging I recommend confirming that it also builds on your system and you can run a HelloWorld without issues.
As a reminder, to run a Cyclone user application, you have to add your `path/to/cyclone_install/bin`, to the `PATH` environment variable.